### PR TITLE
Fix frontend build by pinning react-router to 7.18.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router": "^8.3.0",
+        "react-router": "~7.18.2",
         "react-scripts": "^5.0.1",
         "recharts": "^2.15.4",
         "sass": "^1.93.3",
@@ -7756,12 +7756,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-es": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
-      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -18446,24 +18440,38 @@
       }
     },
     "node_modules/react-router": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
-      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^3.1.1"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=22.22.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=19.2.7",
-        "react-dom": ">=19.2.7"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-scripts": {
@@ -19547,6 +19555,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -27283,11 +27297,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
-    "cookie-es": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
-    },
     "cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -34622,11 +34631,19 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
-      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "requires": {
-        "cookie-es": "^3.1.1"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+          "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
+        }
       }
     },
     "react-scripts": {
@@ -35400,6 +35417,11 @@
           "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router": "^8.3.0",
+    "react-router": "~7.18.2",
     "react-scripts": "^5.0.1",
     "recharts": "^2.15.4",
     "sass": "^1.93.3",


### PR DESCRIPTION
The frontend production build is currently broken on `master`. This restores it.

## The problem

`react-router@8.3.0` declares `peerDependencies: { react: ">=19.2.7" }`, but the project pins `react ^18.2.0` (18.3.1 installed). `npm run build` fails with:

```
Attempted import error: 'useOptimistic' is not exported from 'react'
```

`useOptimistic` is a React 19 hook. This has been broken since react-router was upgraded to 8.3.0.

## The change

One line — `react-router` `^8.3.0` → `~7.18.2`, the newest release compatible with React 18. `npm run build` now reports **`Compiled successfully`** (278.31 kB gzipped).

All four APIs the app imports (`BrowserRouter`, `Routes`, `Route`, `Link`) are verified present in 7.18.2. The tilde range prevents drift back into 8.x.

## Trade-off worth understanding before merging

**No react-router version is both React 18-compatible and advisory-free:**

| Version | React 18 | Advisories |
|---|---|---|
| 6.0.0 – 7.17.0 | yes | **11 high** — RCE, multiple XSS, DoS |
| **7.18.2 (this PR)** | yes | **1 high** — [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) |
| 8.3.0 (current) | **no** | none |

7.18.2 is the best option available on React 18.

**On the remaining advisory:** GHSA-qwww-vcr4-c8h2 is an RSC-mode CSRF bypass. It requires React Server Components with a server runtime processing actions. This app is a static CRA SPA using `BrowserRouter` — no RSC, no server actions, no loaders — so the affected path is not reachable. Reviewer judgment welcome on accepting that.

Expect `npm audit` to keep reporting it, and Dependabot to keep proposing 8.3.0, which reintroduces the build break.

## The longer-term fix

The clean end state is React 19 + react-router 8.3.0. That is blocked on `@material-ui/core@4`, which caps at `react ^16.8.0 || ^17.0.0` and is EOL. Migrating to `@mui/material` touches **20 of 49 source files** and requires rewriting **22 `makeStyles` call sites** (the JSS engine was removed in MUI v5), plus `styled-components` 5→6 and `@testing-library/react` 11→16. That is a deliberate project, not a dependency bump — this PR unblocks the build in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)