### PR TITLE
Fix nanoid and js-yaml vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14860,9 +14860,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -15568,9 +15568,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -23593,7 +23593,7 @@
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -23681,7 +23681,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -28343,7 +28343,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -32268,9 +32268,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -32803,9 +32803,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,7 @@
     "uuid": "^14.0.0",
     "shell-quote": "^1.10.0",
     "launch-editor": "^2.14.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "http-proxy-middleware": "^2.0.10",
     "qs": "^6.15.2",
     "protobufjs": "^8.4.2",


### PR DESCRIPTION
Clears both remaining high-severity advisories in the frontend. **`npm audit` now reports 0 vulnerabilities in both workspaces.**

## Changes

| Package | Before | After | Advisory |
|---|---|---|---|
| `nanoid` | 3.3.16 | 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators loop indefinitely when size is zero (`< 3.3.18`) |
| `js-yaml` | 4.3.0 | 4.3.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution (`4.0.0 - 4.3.0`) |

- **nanoid** arrives via `react-scripts@5.0.1 -> postcss@8.5.23`, which declares `nanoid ^3.3.16`. 3.3.18 is inside that range, so this is a lockfile-only change — no `overrides` entry required.
- **js-yaml** was pinned by an existing override at `^4.3.0`, which sat exactly at the top of the vulnerable range. Bumped to `^4.3.1`.

### Why 3.3.18 and not nanoid 4/5/6

3.3.18 is the final release of the 3.x line, published under the `legacy` dist-tag (`latest` is 6.0.1). Later majors are ESM-only and fall outside the `^3.3.16` range postcss expects, so forcing one would break the CRA build. 3.3.18 is the correct target, not a floor to exceed.

## Verification

- `npm audit`: **0 vulnerabilities** in `frontend/` and `backend/`
- `npm run build`: **Compiles successfully** (278.31 kB gzipped, unchanged)

## Related

Since #166 merged, GHSA-qwww-vcr4-c8h2 has been re-scoped upstream — the affected range narrowed from `>= 7.12.0, < 8.3.0` to `>= 7.12.0, < 7.18.2`, and **7.18.2 is now listed as patched**. The react-router pin from that PR is therefore a genuine fix rather than an accepted risk, and the caveat recorded there no longer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)